### PR TITLE
fix: Fixed typo in the workflow section

### DIFF
--- a/src/components/Workflow.tsx
+++ b/src/components/Workflow.tsx
@@ -7,7 +7,7 @@ export default function Workflow() {
         <div className={styles.workflowStep}>
           <h2 className={styles.stepTitle}>1. Guideline curation</h2>
           <p className={styles.stepDescription}>
-            Manitainers design the contribution flow for the contributors.
+            Maintainers design the contribution flow for the contributors.
           </p>
         </div>
         <div className={styles.workflowStep}>


### PR DESCRIPTION
This PR fixes the typo "manitainers" --> "maintainers" in the workflow section.