### PR TITLE
feat: Adds Chatwoot widget for customer support

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,15 @@
+interface ChatwootSettings {
+  hideMessageBubble: boolean;
+  position: string;
+  locale: string;
+  type: string;
+}
+
+interface ChatwootSDK {
+  run: (config: { websiteToken: string; baseUrl: string }) => void;
+}
+
+interface Window {
+  chatwootSettings?: ChatwootSettings;
+  chatwootSDK?: ChatwootSDK;
+}

--- a/src/components/ChatwootWidget.tsx
+++ b/src/components/ChatwootWidget.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export class ChatwootWidget extends React.Component {
+  componentDidMount() {
+    // Add Chatwoot Settings
+    window.chatwootSettings = {
+      hideMessageBubble: false,
+      position: "right", // This can be left or right
+      locale: "en", // Language to be set
+      type: "standard", // [standard, expanded_bubble]
+    };
+
+    // Paste the script from inbox settings except the <script> tag
+    (function (d, t) {
+      if (process.env.NEXT_PUBLIC_CHATWOOT_TOKEN) {
+        const chatwootToken: string = process.env.NEXT_PUBLIC_CHATWOOT_TOKEN;
+        const BASE_URL =
+          process.env.NEXT_PUBLIC_CHATWOOT_ENDPOINT ||
+          "https://app.chatwoot.com";
+        const g = d.createElement(t) as HTMLScriptElement,
+          s = d.getElementsByTagName(t)[0];
+        g.src = BASE_URL + "/packs/js/sdk.js";
+        g.defer = true;
+        g.async = true;
+        s.parentNode?.insertBefore(g, s);
+        g.onload = function () {
+          window.chatwootSDK?.run({
+            websiteToken: chatwootToken,
+            baseUrl: BASE_URL,
+          });
+        };
+      }
+    })(document, "script");
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,9 @@
 import { Analytics } from "@vercel/analytics/react";
 import type { AppProps } from "next/app";
 import Head from "next/head";
+
 import "../styles/globals.css";
+import { ChatwootWidget } from "../components/ChatwootWidget.tsx";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -10,6 +12,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <title>Quack AI - Your companion for developer onboarding</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
+      <ChatwootWidget />
       <Component {...pageProps} />
       <Analytics />
     </>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "globals.d.ts",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR adds a customer chat widget to the website using Chatwoot. Here is how it renders:

![image](https://github.com/quack-ai/quack-ai.github.io/assets/26927750/5de71c8b-97f0-4ef5-bb40-33f785d7c964)
